### PR TITLE
chore(ci): add inline rationale comments

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Validate JSON/YAML
         uses: GrantBirki/json-yaml-validate@v3
-        continue-on-error: true
+        continue-on-error: true  # May fail on template files or non-standard formats
 
       - name: Lint GitHub Actions workflows
         uses: docker://rhysd/actionlint:latest
@@ -133,7 +133,7 @@ jobs:
 
       - name: Check dependency licenses
         uses: actions/dependency-review-action@v4
-        continue-on-error: true
+        continue-on-error: true  # Requires GHAS on private repos; non-blocking fallback
         with:
           allow-licenses: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, WTFPL, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Python-2.0, PSF-2.0, MPL-2.0
 


### PR DESCRIPTION
## Summary
- Adds inline comments explaining *why* `continue-on-error: true` is set on `json-yaml-validate` and `dependency-review-action` steps
- Aligns compass-engine with all other 11 repos that already have these comments

## Changes
- `json-yaml-validate`: `# May fail on template files or non-standard formats`
- `dependency-review-action`: `# Requires GHAS on private repos; non-blocking fallback`

## Test plan
- [ ] CI passes (no functional change, comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow documentation with clarifying comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->