### PR TITLE
chore: add dependabot for BMAD-METHOD submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,13 @@ updates:
     labels:
       - "dependencies"
       - "npm"
+
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+      - "submodule"
+    allow:
+      - dependency-name: "BMAD-METHOD"


### PR DESCRIPTION
## Summary
- Adds a `gitsubmodule` ecosystem entry to Dependabot config
- Scoped to only the `BMAD-METHOD` submodule using `allow` filter
- Checks daily for new commits on BMAD-METHOD main and opens PRs automatically
- Prevents the submodule pointer from going stale (which caused the recent recursive update failure)

## Test plan
- [ ] Verify Dependabot picks up the config and starts monitoring BMAD-METHOD
- [ ] Confirm no PRs are opened for other submodules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency update configuration to include git submodules with daily check schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->