### PR TITLE
fix(init-planning): make oversight scaffold a distinct step

### DIFF
--- a/src/bmad/modules/custom/bmm/workflows/planning/init-planning/checklist.md
+++ b/src/bmad/modules/custom/bmm/workflows/planning/init-planning/checklist.md
@@ -32,6 +32,13 @@
 - [ ] Missing or incomplete live files were reported instead of silently overwritten
 - [ ] For `delivery` scope: orchestration files were not seeded, migrated, or reported as gaps
 
+## Oversight Substrate
+
+- [ ] When `{oversight_mode}` is `true`: `{current_oversight_dir}` exists
+- [ ] When `{oversight_mode}` is `true`: `{current_oversight_dir}/risks.yaml` exists (copied from template)
+- [ ] When `{oversight_mode}` is `true`: `{current_oversight_dir}/assumptions.yaml` exists (copied from template)
+- [ ] When `{oversight_mode}` is `false`: oversight directory was not created
+
 ## Outputs
 
 - [ ] Initialization report written to `{default_output_file}`

--- a/src/bmad/modules/custom/bmm/workflows/planning/init-planning/instructions.md
+++ b/src/bmad/modules/custom/bmm/workflows/planning/init-planning/instructions.md
@@ -118,6 +118,7 @@ Ensure these directories exist:
 - `{planning_current}/testing/gates/draft/security/`
 - `{planning_current}/testing/gates/security/readiness/`
 - `{planning_current}/testing/gates/security/release/`
+- `{planning_current}/oversight/`
 - `{planning_roadmap}/brainstorming/`
 - `{planning_roadmap}/research/market/`
 - `{planning_roadmap}/research/domain/`
@@ -133,7 +134,17 @@ Ensure these directories exist:
 - `{planning_roadmap}/archive/storytelling/`
 - `{planning_roadmap}/archive/product-brief/`
 
-If `{oversight_mode}` is `true`, ensure `{current_oversight_dir}` exists. If it does not exist, create it and copy the template files from `{planning_templates_root}/oversight/risks.yaml` and `{planning_templates_root}/oversight/assumptions.yaml` into it.
+### Step 4a: Scaffold Oversight Directory
+
+<critical>This step is mandatory when `{oversight_mode}` is `true` (the default).</critical>
+
+When `{oversight_mode}` is `true`:
+
+1. Create `{current_oversight_dir}` if it does not exist.
+2. Copy `{planning_templates_root}/oversight/risks.yaml` into `{current_oversight_dir}/risks.yaml` if it does not already exist.
+3. Copy `{planning_templates_root}/oversight/assumptions.yaml` into `{current_oversight_dir}/assumptions.yaml` if it does not already exist.
+
+When `{oversight_mode}` is `false`, skip this step.
 
 ## Step 5: Seed or Preserve the Authority Files
 


### PR DESCRIPTION
## Summary

The oversight directory scaffold instruction was buried as a trailing paragraph after a 40-line directory list in init-planning. Agents skipped it during the smoke test.

**Fix:**
- Promoted to **Step 4a** with a `<critical>` tag
- Added `{planning_current}/oversight/` to the directory creation list
- Added oversight verification items to the checklist

**Verified:** Re-ran init-planning in compass-tests — oversight directory and template files now created correctly.

## Test plan

- [x] Smoke tested: `opencode run` with init-planning creates `planning/current/oversight/` with `risks.yaml` and `assumptions.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added oversight substrate validation to planning checklist with mode-conditional assertions
  * Implemented oversight directory scaffolding step that creates the directory and deploys template files (risks.yaml, assumptions.yaml) when enabled

* **Documentation**
  * Enhanced planning workflow instructions with dedicated oversight setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->