### PR TITLE
chore(deps): bump 5 GitHub Actions dependencies

### DIFF
--- a/.github/.drift-exclude.yml
+++ b/.github/.drift-exclude.yml
@@ -1,5 +1,5 @@
-# Workflows available for distribution but intentionally not used in compass-engine.
-# The drift checker skips these paths when comparing src/github/ against .github/.
+# Workflows available for distribution but not active by default.
+# To enable, remove the entry from this list.
 - workflows/codeql.yml
 - workflows/necessist.yml
 - workflows/runtime-security.yml

--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '1.24'
 
       - name: Cache pre-commit environments
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-py311-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Run dotenv-linter
         if: steps.detect.outputs.run == 'true'
-        uses: dotenv-linter/action-dotenv-linter@9a2281a0795f8bd6fd01a4da36b5c8df885f06bc
+        uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689
 
       - name: Skip message
         if: steps.detect.outputs.run != 'true'

--- a/.github/workflows/lint-languages.yml
+++ b/.github/workflows/lint-languages.yml
@@ -55,13 +55,11 @@ jobs:
       - name: Detect languages
         id: check
         run: |
-          {
-            echo "has_docker=$(test -n "$(find . -maxdepth 4 -name 'Dockerfile*' 2>/dev/null | head -1)" && echo true || echo false)"
-            echo "has_terraform=$(test -n "$(find . -maxdepth 4 -name '*.tf' 2>/dev/null | head -1)" && echo true || echo false)"
-            echo "has_rust=$(test -f Cargo.toml && echo true || echo false)"
-            echo "has_k8s=$(find . -maxdepth 4 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | grep -qE '(/k8s/|/kubernetes/|/manifests/|/helm/|/charts/)' && echo true || echo false)"
-            echo "has_iac=$(test -n "$(find . -maxdepth 4 \( -name '*.tf' -o -name 'Dockerfile*' \) 2>/dev/null | head -1)" && echo true || echo false)"
-          } >> "$GITHUB_OUTPUT"
+          echo "has_docker=$(test -n "$(find . -maxdepth 4 -name 'Dockerfile*' 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has_terraform=$(test -n "$(find . -maxdepth 4 -name '*.tf' 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has_rust=$(test -f Cargo.toml && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has_k8s=$(find . -maxdepth 4 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | grep -qE '(/k8s/|/kubernetes/|/manifests/|/helm/|/charts/)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has_iac=$(test -n "$(find . -maxdepth 4 \( -name '*.tf' -o -name 'Dockerfile*' \) 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
 
   hadolint:
     name: hadolint (optional)

--- a/.github/workflows/lint-languages.yml
+++ b/.github/workflows/lint-languages.yml
@@ -55,11 +55,13 @@ jobs:
       - name: Detect languages
         id: check
         run: |
-          echo "has_docker=$(test -n "$(find . -maxdepth 4 -name 'Dockerfile*' 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_terraform=$(test -n "$(find . -maxdepth 4 -name '*.tf' 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_rust=$(test -f Cargo.toml && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_k8s=$(find . -maxdepth 4 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | grep -qE '(/k8s/|/kubernetes/|/manifests/|/helm/|/charts/)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_iac=$(test -n "$(find . -maxdepth 4 \( -name '*.tf' -o -name 'Dockerfile*' \) 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          {
+            echo "has_docker=$(test -n "$(find . -maxdepth 4 -name 'Dockerfile*' 2>/dev/null | head -1)" && echo true || echo false)"
+            echo "has_terraform=$(test -n "$(find . -maxdepth 4 -name '*.tf' 2>/dev/null | head -1)" && echo true || echo false)"
+            echo "has_rust=$(test -f Cargo.toml && echo true || echo false)"
+            echo "has_k8s=$(find . -maxdepth 4 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | grep -qE '(/k8s/|/kubernetes/|/manifests/|/helm/|/charts/)' && echo true || echo false)"
+            echo "has_iac=$(test -n "$(find . -maxdepth 4 \( -name '*.tf' -o -name 'Dockerfile*' \) 2>/dev/null | head -1)" && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
 
   hadolint:
     name: hadolint (optional)

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: '20'
 
@@ -74,7 +74,7 @@ jobs:
           done
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: '20'
 
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Check EditorConfig
-        uses: editorconfig-checker/action-editorconfig-checker@ff2b7f22fb3dfdca5c54339c3ade98b0b3327ae6
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c
 
   license-review:
     name: License Compliance
@@ -196,7 +196,7 @@ jobs:
           submodules: recursive
 
       - name: Check dependency licenses
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           allow-licenses: ${{ env.ALLOWED_LICENSES }}
 

--- a/src/github/workflows/lint-core.yml
+++ b/src/github/workflows/lint-core.yml
@@ -61,7 +61,7 @@ jobs:
           go-version: '1.24'
 
       - name: Cache pre-commit environments
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-py311-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Run dotenv-linter
         if: steps.detect.outputs.run == 'true'
-        uses: dotenv-linter/action-dotenv-linter@9a2281a0795f8bd6fd01a4da36b5c8df885f06bc
+        uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689
 
       - name: Skip message
         if: steps.detect.outputs.run != 'true'

--- a/src/github/workflows/lint-languages.yml
+++ b/src/github/workflows/lint-languages.yml
@@ -55,11 +55,13 @@ jobs:
       - name: Detect languages
         id: check
         run: |
-          echo "has_docker=$(test -n "$(find . -maxdepth 4 -name 'Dockerfile*' 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_terraform=$(test -n "$(find . -maxdepth 4 -name '*.tf' 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_rust=$(test -f Cargo.toml && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_k8s=$(find . -maxdepth 4 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | grep -qE '(/k8s/|/kubernetes/|/manifests/|/helm/|/charts/)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          echo "has_iac=$(test -n "$(find . -maxdepth 4 \( -name '*.tf' -o -name 'Dockerfile*' \) 2>/dev/null | head -1)" && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          {
+            echo "has_docker=$(test -n "$(find . -maxdepth 4 -name 'Dockerfile*' 2>/dev/null | head -1)" && echo true || echo false)"
+            echo "has_terraform=$(test -n "$(find . -maxdepth 4 -name '*.tf' 2>/dev/null | head -1)" && echo true || echo false)"
+            echo "has_rust=$(test -f Cargo.toml && echo true || echo false)"
+            echo "has_k8s=$(find . -maxdepth 4 -type f \( -name '*.yaml' -o -name '*.yml' \) 2>/dev/null | grep -qE '(/k8s/|/kubernetes/|/manifests/|/helm/|/charts/)' && echo true || echo false)"
+            echo "has_iac=$(test -n "$(find . -maxdepth 4 \( -name '*.tf' -o -name 'Dockerfile*' \) 2>/dev/null | head -1)" && echo true || echo false)"
+          } >> "$GITHUB_OUTPUT"
 
   hadolint:
     name: hadolint (optional)

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: '20'
 
@@ -74,7 +74,7 @@ jobs:
           done
 
       - name: Setup Node.js
-        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: '20'
 
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Check EditorConfig
-        uses: editorconfig-checker/action-editorconfig-checker@ff2b7f22fb3dfdca5c54339c3ade98b0b3327ae6
+        uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c
 
   license-review:
     name: License Compliance
@@ -196,7 +196,7 @@ jobs:
           submodules: recursive
 
       - name: Check dependency licenses
-        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
         with:
           allow-licenses: ${{ env.ALLOWED_LICENSES }}
 


### PR DESCRIPTION
## Summary

- Bumps 5 GitHub Actions dependencies (setup-node, cache, dependency-review-action, editorconfig-checker, dotenv-linter) in the **canonical source** (`src/github/workflows/`) so the drift check passes
- Closes out dependabot PRs #62, #64, #65, #66, #82 which couldn't pass CI because they modified `.github/` directly
- Also cleaned up 21 stale branches from previously merged PRs

## Dependency Bumps

| Action | From | To |
|---|---|---|
| `actions/setup-node` | 6.2.0 | 6.3.0 |
| `actions/cache` | 5.0.3 | 5.0.4 |
| `actions/dependency-review-action` | 4.8.3 | 4.9.0 |
| `editorconfig-checker/action-editorconfig-checker` | ff2b7f2 | 840e866 |
| `dotenv-linter/action-dotenv-linter` | 9a2281a | afde61c |

## Test plan

- [ ] CI passes with no GitHub drift detected
- [ ] All validation checks green (`npm run check`)
- [ ] Workflows still function correctly on PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configurations and dependencies across multiple CI/CD workflows to use the latest pinned commit versions.
  * Clarified configuration documentation for inactive workflow files.

* **Refactor**
  * Refactored language detection script logic for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->