### PR TITLE
fix(push): add missing consumer repos to default candidates

### DIFF
--- a/tools/push.js
+++ b/tools/push.js
@@ -21,10 +21,15 @@ const DEFAULT_PROJECT_CANDIDATES = [
   'compass-modules',
   'compass-brand-infrastructure',
   'compass-brand-setup',
+  'compass-tests',
   'mcps',
   'compass-services/legacy-system-analyzer',
   'compass-services/competitor-analysis-toolkit',
   'compass-forge/constellation',
+  'compass-forge/forge-rag',
+  'compass-forge/forge-providers',
+  'compass-tests/embedding-tests',
+  'compass-tests/ai-documentation-testing',
 ];
 
 const TARGETS = {


### PR DESCRIPTION
## Summary

Completes compass-engine distribution by adding 5 missing consumer repos to `DEFAULT_PROJECT_CANDIDATES` in `tools/push.js`. Without these entries, `npm run push -- --all` silently skipped these projects, resulting in incomplete distribution (audit flagged them as MISSING or MINIMAL-only).

## Changes

- **tools/push.js**: add to `DEFAULT_PROJECT_CANDIDATES`:
  - `compass-tests` (top-level, never pushed via defaults)
  - `compass-forge/forge-rag` (was MINIMAL — only `planning/`)
  - `compass-forge/forge-providers` (was MINIMAL — only `planning/`)
  - `compass-tests/embedding-tests` (never pushed)
  - `compass-tests/ai-documentation-testing` (was MINIMAL)

## Test plan

- [x] `npm run push -- --dry-run --all` reports `Found 16 projects` and syncs to all 16 consumer paths (workspace root + 15 submodules; compass-engine source is correctly skipped)
- [x] No regressions: all 11 pre-existing candidates continue to resolve
- [x] Sensitive files excluded (no `.env`, `*.local.json`, `*.pem`, `.npmrc`)
- [x] `gh pr checks` green (Pre-Push Validation + Security Scan)

## Context

Part of workspace-wide cleanup (compass_brand Phase 0.5a). Enables downstream Phase 2 per-repo cleanups to run `npm run push:no-build -- --project <path>` atomically for all 16 consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project discovery configuration to automatically detect and sync additional workspace directories when using workspace-wide synchronization operations, ensuring more projects are included in discovery workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->