### PR TITLE
fix(ci): upgrade trivy-action and fix hadolint recursive glob

### DIFF
--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Run Trivy
         if: steps.detect.outputs.run == 'true'
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scanners: vuln,misconfig,secret

--- a/.github/workflows/lint-languages.yml
+++ b/.github/workflows/lint-languages.yml
@@ -79,6 +79,7 @@ jobs:
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
         with:
           recursive: true
+          dockerfile: Dockerfile.*
           failure-threshold: error
 
   checkov:

--- a/.github/workflows/submodule-security-monitoring.yml
+++ b/.github/workflows/submodule-security-monitoring.yml
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: .

--- a/src/github/workflows/lint-core.yml
+++ b/src/github/workflows/lint-core.yml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Run Trivy
         if: steps.detect.outputs.run == 'true'
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scanners: vuln,misconfig,secret

--- a/src/github/workflows/lint-languages.yml
+++ b/src/github/workflows/lint-languages.yml
@@ -79,6 +79,7 @@ jobs:
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
         with:
           recursive: true
+          dockerfile: Dockerfile.*
           failure-threshold: error
 
   checkov:

--- a/src/github/workflows/submodule-security-monitoring.yml
+++ b/src/github/workflows/submodule-security-monitoring.yml
@@ -52,7 +52,7 @@ jobs:
           submodules: recursive
 
       - name: Run Trivy
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
           scan-ref: .


### PR DESCRIPTION
## Summary

Two systemic CI failures surfaced on downstream consumer repos (mcps PR #13) after PR #118 landed:

1. **Trivy install.sh bootstrap failure** — the pinned `aquasecurity/trivy-action` SHA (v0.11.2-era) sparse-checks-out the trivy repo and runs `install.sh -b /home/runner/.local/bin/trivy-bin v0.69.1`, exiting 1 immediately after version resolution on current runners. Bumped pin to `v0.35.0` (`57a97c7e7821a5776cebc9bb87c984fa69cba8f1`), which uses the standard GH-Actions install path. Matches the "absolute-path YAML bootstrap" upstream follow-up noted in memory.

2. **hadolint false-positive on non-default Dockerfile names** — the `detect` job in `lint-languages.yml` sets `has_docker=true` for any `Dockerfile*` glob, but hadolint-action in recursive mode with default `dockerfile: Dockerfile` only matches files literally named `Dockerfile`. Consumer repos with variants (e.g. mcps's `Dockerfile.serena`) triggered the job, then failed with `**/Dockerfile: does not exist`. Fixed by passing `dockerfile: Dockerfile.*` so the recursive regex matches the same set the detect job emits.

Follows up PR #118 (language-conditional quality-checks).

## Files

- `src/github/workflows/lint-core.yml` — trivy-action SHA bump
- `src/github/workflows/submodule-security-monitoring.yml` — trivy-action SHA bump
- `src/github/workflows/lint-languages.yml` — hadolint dockerfile glob
- `.github/workflows/*` — mirrored via `push.js` to keep drift-check green

## Security posture

Unchanged — same scanners (vuln/misconfig/secret), same severity gates (HIGH,CRITICAL), same SARIF upload, same `exit-code` semantics. This is strictly a version bump + glob fix.

## Test plan

- [x] YAML validates (`npm run check` — drift checks pass, validate passes)
- [x] `npm run build` succeeds
- [ ] CI on this PR: Trivy job passes (compass-engine has package.json so positive path runs)
- [ ] CI on this PR: hadolint job skipped (compass-engine has no Dockerfile, so `has_docker=false`)
- [ ] After merge: re-run mcps PR #13 CI and confirm both hadolint and Trivy succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)