### PR TITLE
fix(ci): enable multi-document YAML in syntax validation

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -223,6 +223,7 @@ jobs:
         with:
           json_exclude_regex: '(^|/)fixtures/|(^|/)tests/fixtures/'
           yaml_exclude_regex: '(^|/)fixtures/|(^|/)tests/fixtures/'
+          allow_multiple_documents: "true"
 
       - name: Lint GitHub Actions workflows
         uses: rhysd/actionlint@2df6872d4bde2b030214429d65f7aeee79ceee47

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -223,6 +223,7 @@ jobs:
         with:
           json_exclude_regex: '(^|/)fixtures/|(^|/)tests/fixtures/'
           yaml_exclude_regex: '(^|/)fixtures/|(^|/)tests/fixtures/'
+          allow_multiple_documents: "true"
 
       - name: Lint GitHub Actions workflows
         uses: rhysd/actionlint@2df6872d4bde2b030214429d65f7aeee79ceee47


### PR DESCRIPTION
## Summary

The distributed Syntax Validation job uses `GrantBirki/json-yaml-validate`, which defaults to **single-document** YAML parsing. Kubernetes manifests conventionally bundle multiple documents per file with `---` separators; those files fail with:

```
YAMLParseError: Source contains multiple documents; please use YAML.parseAllDocuments()
```

**Surfaced on:** compass-brand-infrastructure PR #8 — 6 k8s multi-doc files (`k8s/namespaces/compass.yaml`, `k8s/namespaces/network-policies.yaml`, +4) all failed Syntax Validation after PR #118 landed.

Follows up PR #118 (Task #24) and PR #119 (Task #25).

## Fix

Pass `allow_multiple_documents: "true"` to the action — a supported input that switches the validator to `parseAllDocuments()` semantics and iterates per-document. The action preserves per-file / per-document error reporting.

## Files

- `src/github/workflows/quality-checks.yml` — action input added
- `.github/workflows/quality-checks.yml` — mirrored via `push.js` for drift-check

## Security posture

Unchanged — same validator, same schema semantics, same failure mode on malformed YAML. Just permits the standard k8s multi-doc convention.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run check` drift-check passes
- [ ] CI on this PR: Syntax Validation passes on compass-engine's own YAML (already single-doc, so no regression expected)
- [ ] Post-merge: re-run compass-brand-infrastructure PR #8 CI and confirm Syntax Validation passes on the 6 k8s multi-doc files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced syntax validation workflow to support multi-document YAML files, improving validation capabilities for complex YAML configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->