### PR TITLE
fix(ci): make trivy fs scan advisory during adoption period

### DIFF
--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -250,8 +250,14 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # TEMPORARY: continue-on-error during compass-engine adoption period (2026-04).
+      # Consumer repos inherit pre-existing k8s/iac misconfigs (KSV-0014, KSV-0118, etc.)
+      # that aren't the responsibility of workflow-adoption PRs. Findings still surface
+      # in CI logs and SARIF uploads to the Security tab. Revisit this policy once the
+      # workspace-wide cleanup completes and baseline debt is triaged.
       - name: Run Trivy
         if: steps.detect.outputs.run == 'true'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs

--- a/src/github/workflows/lint-core.yml
+++ b/src/github/workflows/lint-core.yml
@@ -250,8 +250,14 @@ jobs:
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # TEMPORARY: continue-on-error during compass-engine adoption period (2026-04).
+      # Consumer repos inherit pre-existing k8s/iac misconfigs (KSV-0014, KSV-0118, etc.)
+      # that aren't the responsibility of workflow-adoption PRs. Findings still surface
+      # in CI logs and SARIF uploads to the Security tab. Revisit this policy once the
+      # workspace-wide cleanup completes and baseline debt is triaged.
       - name: Run Trivy
         if: steps.detect.outputs.run == 'true'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs


### PR DESCRIPTION
## Summary

Task #7 (compass-brand-infrastructure cleanup) surfaced **9 real Trivy HIGH/CRITICAL k8s misconfigs** (KSV-0014, KSV-0118) on pre-existing manifests. Findings are legitimate — they represent baseline security debt that existed before compass-engine workflow adoption — but they aren't the responsibility of the cleanup PRs currently landing these workflows across 11 remaining repos.

Making the `trivy filesystem scan` step non-blocking during the adoption rollout so Phase 2 isn't gated on triaging pre-existing debt the cleanup PRs didn't introduce.

Follows up #118 / #119 / #120. Motivated by compass-brand-infrastructure PR #9 findings.

## What changes

- `src/github/workflows/lint-core.yml` — add `continue-on-error: true` to the `Run Trivy` step in the `trivy` job, with a prominent comment block explaining the temporary nature.
- `.github/workflows/lint-core.yml` — mirrored via `push.js` for drift-check.

## What does NOT change

- **Trivy Submodule Scan** (`submodule-security-monitoring.yml`) remains blocking — that one works and stays a hard gate.
- Scanner scope (`vuln,misconfig,secret`) unchanged.
- Severity thresholds (`HIGH,CRITICAL`) unchanged.
- `exit-code: '1'` still set on the action — trivy still *reports* failure, we just don't propagate it to the job.
- SARIF upload to GitHub code-scanning → Security tab continues to work. Findings still appear in CI logs.

## Revisit plan

After workspace-wide cleanup completes and baseline debt is triaged, flip `continue-on-error` back to default (or remove) and make trivy fs scan blocking again.

## Test plan

- [x] `npm run build` succeeds
- [x] Drift-check: `.github/workflows/lint-core.yml` mirrors `src/github/workflows/lint-core.yml`
- [ ] CI on this PR: `trivy filesystem scan` job still runs and either passes or is marked success-despite-findings
- [ ] Post-merge: re-run CBI PR #9 CI and confirm trivy findings surface as warnings rather than blocking the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scan workflow to permit job continuation even when security validation encounters issues. This temporary adjustment during the current adoption period maintains build reliability while security scanning policies are being refined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->