### PR TITLE
fix(ci): allow Compass-Brand/* NOASSERTION in License Compliance

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -288,7 +288,16 @@ jobs:
           fi
 
           ALLOWED_SPDX="${ALLOWED_LICENSES//,/ }"
+          # Explicit exact-match allowlist for third-party repos whose GitHub
+          # license API returns NOASSERTION (e.g. BMAD-METHOD ships a license
+          # file GitHub's detector doesn't classify).
           NOASSERTION_ALLOWED_REPOS="bmad-code-org/BMAD-METHOD"
+          # Trust-boundary allowlist: repos under orgs we own are auto-allowed
+          # when their license cannot be detected (private repos often return
+          # NOASSERTION regardless of LICENSE-file presence). Scoped to org
+          # prefixes only — third-party repos still require explicit entry
+          # in NOASSERTION_ALLOWED_REPOS.
+          NOASSERTION_ALLOWED_ORG_PREFIXES="Compass-Brand/"
 
           while read -r _ url; do
             repo="$url"
@@ -318,6 +327,19 @@ jobs:
             if [ "$spdx" = "NOASSERTION" ]; then
               if echo " ${NOASSERTION_ALLOWED_REPOS} " | grep -Fq " ${repo} "; then
                 echo "::warning::License SPDX is NOASSERTION for reviewed submodule ${repo}"
+                continue
+              fi
+              org_allowed=false
+              for prefix in ${NOASSERTION_ALLOWED_ORG_PREFIXES}; do
+                case "$repo" in
+                  "${prefix}"*)
+                    org_allowed=true
+                    break
+                    ;;
+                esac
+              done
+              if [ "$org_allowed" = true ]; then
+                echo "::warning::License SPDX is NOASSERTION for ${repo}; allowed by org trust boundary (${NOASSERTION_ALLOWED_ORG_PREFIXES})"
                 continue
               fi
             fi

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -288,7 +288,16 @@ jobs:
           fi
 
           ALLOWED_SPDX="${ALLOWED_LICENSES//,/ }"
+          # Explicit exact-match allowlist for third-party repos whose GitHub
+          # license API returns NOASSERTION (e.g. BMAD-METHOD ships a license
+          # file GitHub's detector doesn't classify).
           NOASSERTION_ALLOWED_REPOS="bmad-code-org/BMAD-METHOD"
+          # Trust-boundary allowlist: repos under orgs we own are auto-allowed
+          # when their license cannot be detected (private repos often return
+          # NOASSERTION regardless of LICENSE-file presence). Scoped to org
+          # prefixes only — third-party repos still require explicit entry
+          # in NOASSERTION_ALLOWED_REPOS.
+          NOASSERTION_ALLOWED_ORG_PREFIXES="Compass-Brand/"
 
           while read -r _ url; do
             repo="$url"
@@ -318,6 +327,19 @@ jobs:
             if [ "$spdx" = "NOASSERTION" ]; then
               if echo " ${NOASSERTION_ALLOWED_REPOS} " | grep -Fq " ${repo} "; then
                 echo "::warning::License SPDX is NOASSERTION for reviewed submodule ${repo}"
+                continue
+              fi
+              org_allowed=false
+              for prefix in ${NOASSERTION_ALLOWED_ORG_PREFIXES}; do
+                case "$repo" in
+                  "${prefix}"*)
+                    org_allowed=true
+                    break
+                    ;;
+                esac
+              done
+              if [ "$org_allowed" = true ]; then
+                echo "::warning::License SPDX is NOASSERTION for ${repo}; allowed by org trust boundary (${NOASSERTION_ALLOWED_ORG_PREFIXES})"
                 continue
               fi
             fi


### PR DESCRIPTION
## Summary

Task #11 (compass-tests cleanup) surfaced License Compliance failing on **every private Compass-Brand submodule** — GitHub's license-detection API returns `NOASSERTION` for private repos regardless of LICENSE-file presence, and the distributed submodule license check only allowed one explicit exception (`bmad-code-org/BMAD-METHOD`).

Affects compass-tests now (embedding-tests, ai-documentation-testing) and will recur on #20 (compass-forge), #21 (compass-services), #22 (parent workspace).

Follows up #118 / #119 / #120 / #122. Motivated by compass-tests PR #6 failure.

## Fix

Added a **trust-boundary** allowlist for org prefixes we own (`Compass-Brand/`). A submodule with `spdx=NOASSERTION` is allowed **only if** its URL matches one of:
- the exact-match `NOASSERTION_ALLOWED_REPOS` list (unchanged, backward-compatible), **or**
- an org prefix in the new `NOASSERTION_ALLOWED_ORG_PREFIXES` list

Any other NOASSERTION submodule still fails loudly with `::error`.

```diff
  if [ "$spdx" = "NOASSERTION" ]; then
    if echo " ${NOASSERTION_ALLOWED_REPOS} " | grep -Fq " ${repo} "; then
      echo "::warning::..."
      continue
    fi
+   # Trust-boundary check: repos under orgs we own
+   for prefix in ${NOASSERTION_ALLOWED_ORG_PREFIXES}; do
+     case "$repo" in "${prefix}"*) org_allowed=true ;; esac
+   done
+   if [ "$org_allowed" = true ]; then
+     echo "::warning::License SPDX is NOASSERTION for ${repo}; allowed by org trust boundary"
+     continue
+   fi
  fi
```

## What stays blocking

- Third-party submodules with `NOASSERTION` not on the explicit allow list → `::error`, job fails
- Any submodule (including `Compass-Brand/*`) whose SPDX is in a **disallowed** set (e.g. GPL when only permissive licenses are allowed) → `::error`, job fails. The wildcard is only a NOASSERTION-escape hatch, not a "skip license check."
- `actions/dependency-review-action` for package manifests → completely unchanged

## Rationale

We own the `Compass-Brand/*` org; its private repos ship the LICENSE files we control. The `NOASSERTION` value here reflects a limitation of GitHub's public license-detection API for private repos, not a missing license file.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"` passes)
- [x] `npm run build` succeeds
- [x] Drift check: `.github/workflows/quality-checks.yml` mirrors `src/github/workflows/quality-checks.yml`
- [ ] CI on this PR: License Compliance job runs — compass-engine's own `BMAD-METHOD` submodule (third-party, explicit allow) continues to pass; any nested Compass-Brand submodules pass via prefix
- [ ] Post-merge: re-run compass-tests PR #6 and confirm License Compliance succeeds on embedding-tests + ai-documentation-testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced quality-checks workflow to expand submodule license verification with organization-prefix-based allowlisting, enabling broader repository matching while maintaining existing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->