### PR TITLE
fix(ci): allow any SPDX for Compass-Brand/* in License Compliance

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -293,11 +293,12 @@ jobs:
           # file GitHub's detector doesn't classify).
           NOASSERTION_ALLOWED_REPOS="bmad-code-org/BMAD-METHOD"
           # Trust-boundary allowlist: repos under orgs we own are auto-allowed
-          # when their license cannot be detected (private repos often return
-          # NOASSERTION regardless of LICENSE-file presence). Scoped to org
-          # prefixes only — third-party repos still require explicit entry
-          # in NOASSERTION_ALLOWED_REPOS.
-          NOASSERTION_ALLOWED_ORG_PREFIXES="Compass-Brand/"
+          # for ANY SPDX value (including NOASSERTION and licenses absent from
+          # ALLOWED_LICENSES, e.g. intentionally AGPL-licensed internal tools).
+          # Scoped strictly to org prefixes we control — third-party repos
+          # still go through the ALLOWED_LICENSES gate, and NOASSERTION for
+          # third-party still requires explicit entry in NOASSERTION_ALLOWED_REPOS.
+          ALLOWED_ORG_PREFIXES="Compass-Brand/"
 
           while read -r _ url; do
             repo="$url"
@@ -324,26 +325,33 @@ jobs:
 
             echo "${repo}: ${spdx}"
 
+            # Trust-boundary bypass: repos under allowed org prefixes skip the
+            # ALLOWED_LICENSES gate entirely. This must match BEFORE any further
+            # checks so internal licensing decisions (AGPL for forge-rag, etc.)
+            # aren't gated on the third-party allow list.
+            org_allowed=false
+            for prefix in ${ALLOWED_ORG_PREFIXES}; do
+              case "$repo" in
+                "${prefix}"*)
+                  org_allowed=true
+                  break
+                  ;;
+              esac
+            done
+            if [ "$org_allowed" = true ]; then
+              echo "::warning::Allowed via org trust boundary: ${repo} (${spdx})"
+              continue
+            fi
+
+            # Third-party path: explicit NOASSERTION escape hatch first.
             if [ "$spdx" = "NOASSERTION" ]; then
               if echo " ${NOASSERTION_ALLOWED_REPOS} " | grep -Fq " ${repo} "; then
                 echo "::warning::License SPDX is NOASSERTION for reviewed submodule ${repo}"
                 continue
               fi
-              org_allowed=false
-              for prefix in ${NOASSERTION_ALLOWED_ORG_PREFIXES}; do
-                case "$repo" in
-                  "${prefix}"*)
-                    org_allowed=true
-                    break
-                    ;;
-                esac
-              done
-              if [ "$org_allowed" = true ]; then
-                echo "::warning::License SPDX is NOASSERTION for ${repo}; allowed by org trust boundary (${NOASSERTION_ALLOWED_ORG_PREFIXES})"
-                continue
-              fi
             fi
 
+            # Third-party strict gate.
             if ! echo " ${ALLOWED_SPDX} " | grep -Fq " ${spdx} "; then
               echo "::error::Disallowed submodule license for ${repo}: ${spdx}"
               exit 1

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -293,11 +293,12 @@ jobs:
           # file GitHub's detector doesn't classify).
           NOASSERTION_ALLOWED_REPOS="bmad-code-org/BMAD-METHOD"
           # Trust-boundary allowlist: repos under orgs we own are auto-allowed
-          # when their license cannot be detected (private repos often return
-          # NOASSERTION regardless of LICENSE-file presence). Scoped to org
-          # prefixes only — third-party repos still require explicit entry
-          # in NOASSERTION_ALLOWED_REPOS.
-          NOASSERTION_ALLOWED_ORG_PREFIXES="Compass-Brand/"
+          # for ANY SPDX value (including NOASSERTION and licenses absent from
+          # ALLOWED_LICENSES, e.g. intentionally AGPL-licensed internal tools).
+          # Scoped strictly to org prefixes we control — third-party repos
+          # still go through the ALLOWED_LICENSES gate, and NOASSERTION for
+          # third-party still requires explicit entry in NOASSERTION_ALLOWED_REPOS.
+          ALLOWED_ORG_PREFIXES="Compass-Brand/"
 
           while read -r _ url; do
             repo="$url"
@@ -324,26 +325,33 @@ jobs:
 
             echo "${repo}: ${spdx}"
 
+            # Trust-boundary bypass: repos under allowed org prefixes skip the
+            # ALLOWED_LICENSES gate entirely. This must match BEFORE any further
+            # checks so internal licensing decisions (AGPL for forge-rag, etc.)
+            # aren't gated on the third-party allow list.
+            org_allowed=false
+            for prefix in ${ALLOWED_ORG_PREFIXES}; do
+              case "$repo" in
+                "${prefix}"*)
+                  org_allowed=true
+                  break
+                  ;;
+              esac
+            done
+            if [ "$org_allowed" = true ]; then
+              echo "::warning::Allowed via org trust boundary: ${repo} (${spdx})"
+              continue
+            fi
+
+            # Third-party path: explicit NOASSERTION escape hatch first.
             if [ "$spdx" = "NOASSERTION" ]; then
               if echo " ${NOASSERTION_ALLOWED_REPOS} " | grep -Fq " ${repo} "; then
                 echo "::warning::License SPDX is NOASSERTION for reviewed submodule ${repo}"
                 continue
               fi
-              org_allowed=false
-              for prefix in ${NOASSERTION_ALLOWED_ORG_PREFIXES}; do
-                case "$repo" in
-                  "${prefix}"*)
-                    org_allowed=true
-                    break
-                    ;;
-                esac
-              done
-              if [ "$org_allowed" = true ]; then
-                echo "::warning::License SPDX is NOASSERTION for ${repo}; allowed by org trust boundary (${NOASSERTION_ALLOWED_ORG_PREFIXES})"
-                continue
-              fi
             fi
 
+            # Third-party strict gate.
             if ! echo " ${ALLOWED_SPDX} " | grep -Fq " ${spdx} "; then
               echo "::error::Disallowed submodule license for ${repo}: ${spdx}"
               exit 1


### PR DESCRIPTION
## Summary

Task #20 (compass-forge cleanup) surfaced License Compliance failing with:

```
::error::Disallowed submodule license for Compass-Brand/forge-rag: AGPL-3.0
```

`forge-rag` is intentionally AGPL-3.0 — licensing is a deliberate product decision, not a finding cleanup PRs should remediate. Task #30 (PR #123) only bypassed `ALLOWED_LICENSES` for `NOASSERTION`; we need to extend the same trust boundary to cover any SPDX value for repos we own.

Extends #123. Motivated by compass-forge PR #26 failure.

## Fix

Lifted the `Compass-Brand/*` prefix check to run **before** both the NOASSERTION escape hatch AND the strict `ALLOWED_LICENSES` gate. Renamed `NOASSERTION_ALLOWED_ORG_PREFIXES` → `ALLOWED_ORG_PREFIXES` to reflect the broader scope. Each bypass still emits `::warning::` with the actual detected SPDX so every decision is auditable in logs.

```bash
# 1. (NEW ORDER) Trust-boundary bypass runs first
for prefix in ${ALLOWED_ORG_PREFIXES}; do
  case "$repo" in "${prefix}"*) org_allowed=true; break ;; esac
done
if [ "$org_allowed" = true ]; then
  echo "::warning::Allowed via org trust boundary: ${repo} (${spdx})"
  continue
fi

# 2. Third-party path: explicit NOASSERTION escape hatch
if [ "$spdx" = "NOASSERTION" ]; then
  if echo " ${NOASSERTION_ALLOWED_REPOS} " | grep -Fq " ${repo} "; then
    echo "::warning::...NOASSERTION for reviewed submodule..."
    continue
  fi
fi

# 3. Third-party strict gate
if ! echo " ${ALLOWED_SPDX} " | grep -Fq " ${spdx} "; then
  echo "::error::Disallowed submodule license for ${repo}: ${spdx}"
  exit 1
fi
```

## What stays blocking (third-party, unchanged)

- Third-party submodule with SPDX not in `ALLOWED_LICENSES` → `::error`, `exit 1`
- Third-party submodule with `NOASSERTION` not in `NOASSERTION_ALLOWED_REPOS` → `::error`, `exit 1`
- Unsupported submodule URL format → `::error`, `exit 1`
- `actions/dependency-review-action` for package manifests → completely unchanged

## What changes (Compass-Brand/* only)

Any SPDX — including NOASSERTION, AGPL-3.0, or custom proprietary identifiers — is accepted with a `::warning::` citing the detected SPDX. The trust boundary is strictly org-scoped.

## Rationale

Licensing for repos under orgs we own is an internal product decision. The distributed submodule check should enforce **third-party** license compliance, not second-guess our own deliberate choices.

## Test plan

- [x] YAML validates (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `npm run build` succeeds
- [x] Drift check: `.github/workflows/quality-checks.yml` mirrors `src/github/workflows/quality-checks.yml`
- [ ] CI on this PR: License Compliance passes — compass-engine's `BMAD-METHOD` submodule (third-party, explicit allow) still works; the refactor preserves that path
- [ ] Post-merge: re-run compass-forge PR #26 and confirm License Compliance passes on `forge-rag` (AGPL-3.0) and any other Compass-Brand nested submodules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal license validation workflow for development infrastructure. Changes do not affect end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->