### PR TITLE
fix(ci): use SUBMODULES_PAT for private submodule checkouts

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -247,10 +247,13 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
+      # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
+      # Falls back to GITHUB_TOKEN for repos without secret.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
+          token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Detect dependency manifests
         id: detect_deps

--- a/.github/workflows/submodule-security-monitoring.yml
+++ b/.github/workflows/submodule-security-monitoring.yml
@@ -46,10 +46,13 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
+      # Falls back to GITHUB_TOKEN for repos without secret.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
+          token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -134,11 +137,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover-submodules.outputs.matrix) }}
     steps:
+      # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
+      # Falls back to GITHUB_TOKEN for repos without secret.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
           fetch-depth: 0
+          token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Compare pinned commit to upstream
         id: compare

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -247,10 +247,13 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'pull_request'
     steps:
+      # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
+      # Falls back to GITHUB_TOKEN for repos without secret.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
+          token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Detect dependency manifests
         id: detect_deps

--- a/src/github/workflows/submodule-security-monitoring.yml
+++ b/src/github/workflows/submodule-security-monitoring.yml
@@ -46,10 +46,13 @@ jobs:
       contents: read
       security-events: write
     steps:
+      # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
+      # Falls back to GITHUB_TOKEN for repos without secret.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
+          token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
@@ -134,11 +137,14 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.discover-submodules.outputs.matrix) }}
     steps:
+      # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
+      # Falls back to GITHUB_TOKEN for repos without secret.
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
           fetch-depth: 0
+          token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Compare pinned commit to upstream
         id: compare


### PR DESCRIPTION
## Summary

Default `GITHUB_TOKEN` cannot clone private cross-repo submodules even when the submodule repo has `access_level=organization` set — this surfaced on Task #21 (compass-services) where `submodules: recursive` failed to fetch the private LSA/CAT submodules in the License Compliance and Trivy Submodule Scan jobs.

Fix: add a `token` input to every distributed `actions/checkout` that uses `submodules: recursive`, preferring an org-scoped PAT secret and falling back to the default token so repos without the secret still function (all-public-submodules case):

```yaml
token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
```

Consumers set `SUBMODULES_PAT` as an org-scoped fine-grained PAT with `Contents: read` and `Metadata: read` on `Compass-Brand/*` private repos.

## Files changed

- `src/github/workflows/quality-checks.yml` — `license-review` job
- `src/github/workflows/submodule-security-monitoring.yml` — `trivy-submodule-scan` + `monitor-submodule-upstream` jobs
- Mirrored to `.github/workflows/` via `tools/push.js`

## Test plan

- [ ] compass-engine's own PR CI stays green (nested submodules are public; `||` fallback to `GITHUB_TOKEN` keeps it working if SUBMODULES_PAT isn't in scope)
- [ ] Consumer re-run of Task #21 (compass-services) clones LSA/CAT successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced authentication configuration for continuous integration workflows to improve reliability and security when handling project dependencies during automated builds and checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->