### PR TITLE
fix(ci): use SUBMODULES_PAT for gh api calls against submodule repos

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -281,7 +281,9 @@ jobs:
 
       - name: Check submodule repository licenses
         env:
-          GH_TOKEN: ${{ github.token }}
+          # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule metadata.
+          # Falls back to github.token for repos without secret.
+          GH_TOKEN: ${{ secrets.SUBMODULES_PAT || github.token }}
         run: |
           set -euo pipefail
 

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -281,7 +281,9 @@ jobs:
 
       - name: Check submodule repository licenses
         env:
-          GH_TOKEN: ${{ github.token }}
+          # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule metadata.
+          # Falls back to github.token for repos without secret.
+          GH_TOKEN: ${{ secrets.SUBMODULES_PAT || github.token }}
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
## Summary

Follow-up to #125 (Task #33). That PR wired `SUBMODULES_PAT` into `actions/checkout` for submodule cloning, but the `license-review` job's "Check submodule repository licenses" step in `quality-checks.yml` issues `gh api "repos/${repo}"` calls against each submodule repo to fetch SPDX metadata. Those calls are authed by the env `GH_TOKEN`, which still defaulted to `github.token` — and the default token can't query private cross-repo metadata, so license-review 404s on **compass-services PR #10** where LSA/CAT are private.

Fix: apply the same PAT-fallback pattern to the env token:

```yaml
env:
  GH_TOKEN: ${{ secrets.SUBMODULES_PAT || github.token }}
```

## Scope audit

Grepped all distributed workflows for `GH_TOKEN`, `GITHUB_TOKEN`, and `gh api`. Only one `gh api` call queries submodule repos (`quality-checks.yml:327`). Same-repo calls (e.g. `pr-size-labeler` action with `GITHUB_TOKEN`) keep the default token — no broadening of PAT blast radius.

## Files changed

- `src/github/workflows/quality-checks.yml` — `license-review` job, submodule license step env
- Mirrored to `.github/workflows/` via `tools/push.js`

## Test plan

- [ ] compass-engine's own PR CI stays green (license-review on public nested submodules)
- [ ] compass-services PR #10 retry clears License Compliance on next rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)