### PR TITLE
chore: apply ruff format to bmad-distillator scripts

### DIFF
--- a/src/bmad/modules/native/core-skills/bmad-distillator/scripts/analyze_sources.py
+++ b/src/bmad/modules/native/core-skills/bmad-distillator/scripts/analyze_sources.py
@@ -39,8 +39,15 @@ INCLUDE_EXTENSIONS = {".md", ".txt", ".yaml", ".yml", ".json"}
 
 # Directories to skip when scanning folders
 SKIP_DIRS = {
-    "node_modules", ".git", "__pycache__", ".venv", "venv",
-    ".claude", "_bmad-output", ".cursor", ".vscode",
+    "node_modules",
+    ".git",
+    "__pycache__",
+    ".venv",
+    "venv",
+    ".claude",
+    "_bmad-output",
+    ".cursor",
+    ".vscode",
 }
 
 # Approximate chars per token for estimation
@@ -143,17 +150,21 @@ def suggest_groups(files: list[Path]) -> list[dict]:
                     groups[group_key] = []
                     # Add the base file if it exists
                     if base_name in file_map and base_name not in assigned:
-                        groups[group_key].append({
-                            "path": str(file_map[base_name]),
-                            "filename": base_name,
-                            "role": "primary",
-                        })
+                        groups[group_key].append(
+                            {
+                                "path": str(file_map[base_name]),
+                                "filename": base_name,
+                                "role": "primary",
+                            }
+                        )
                         assigned.add(base_name)
-                groups[group_key].append({
-                    "path": str(f),
-                    "filename": f.name,
-                    "role": "companion",
-                })
+                groups[group_key].append(
+                    {
+                        "path": str(f),
+                        "filename": f.name,
+                        "role": "companion",
+                    }
+                )
                 assigned.add(f.name)
                 matched = True
                 break
@@ -162,23 +173,31 @@ def suggest_groups(files: list[Path]) -> list[dict]:
             # Check if this file is a base that already has companions
             if f.name in groups:
                 continue  # Already added as primary
-            ungrouped.append({
-                "path": str(f),
-                "filename": f.name,
-            })
+            ungrouped.append(
+                {
+                    "path": str(f),
+                    "filename": f.name,
+                }
+            )
 
     result = []
     for group_key, members in groups.items():
-        result.append({
-            "group_key": group_key,
-            "files": members,
-        })
+        result.append(
+            {
+                "group_key": group_key,
+                "files": members,
+            }
+        )
     for ug in ungrouped:
         if ug["filename"] not in assigned:
-            result.append({
-                "group_key": ug["filename"],
-                "files": [{"path": ug["path"], "filename": ug["filename"], "role": "standalone"}],
-            })
+            result.append(
+                {
+                    "group_key": ug["filename"],
+                    "files": [
+                        {"path": ug["path"], "filename": ug["filename"], "role": "standalone"}
+                    ],
+                }
+            )
 
     return result
 
@@ -202,13 +221,15 @@ def analyze(inputs: list[str], output_path: str | None = None) -> None:
     for f in files:
         size = f.stat().st_size
         total_chars += size
-        file_details.append({
-            "path": str(f),
-            "filename": f.name,
-            "size_bytes": size,
-            "estimated_tokens": size // CHARS_PER_TOKEN,
-            "doc_type": detect_doc_type(f.name),
-        })
+        file_details.append(
+            {
+                "path": str(f),
+                "filename": f.name,
+                "size_bytes": size,
+                "estimated_tokens": size // CHARS_PER_TOKEN,
+                "doc_type": detect_doc_type(f.name),
+            }
+        )
 
     total_tokens = total_chars // CHARS_PER_TOKEN
     groups = suggest_groups(files)
@@ -288,7 +309,8 @@ def main() -> None:
         help="File paths, folder paths, or glob patterns to analyze",
     )
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         help="Output JSON to file instead of stdout",
     )
     args = parser.parse_args()

--- a/src/bmad/modules/native/core-skills/bmad-distillator/scripts/tests/test_analyze_sources.py
+++ b/src/bmad/modules/native/core-skills/bmad-distillator/scripts/tests/test_analyze_sources.py
@@ -10,6 +10,7 @@ import pytest
 
 # Add parent dir to path so we can import the script
 import sys
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from analyze_sources import (
@@ -95,24 +96,27 @@ class TestResolveInputs:
 
 
 class TestDetectDocType:
-    @pytest.mark.parametrize("filename,expected", [
-        ("product-brief-foo.md", "product-brief"),
-        ("product_brief_bar.md", "product-brief"),
-        ("foo-discovery-notes.md", "discovery-notes"),
-        ("foo-discovery_notes.md", "discovery-notes"),
-        ("architecture-overview.md", "architecture-doc"),
-        ("my-prd.md", "prd"),
-        ("research-report-q4.md", "research-report"),
-        ("foo-distillate.md", "distillate"),
-        ("changelog.md", "changelog"),
-        ("readme.md", "readme"),
-        ("api-spec.md", "specification"),
-        ("design-doc-v2.md", "design-doc"),
-        ("meeting-notes-2026.md", "meeting-notes"),
-        ("brainstorm-session.md", "brainstorming"),
-        ("user-interview-notes.md", "interview-notes"),
-        ("random-file.md", "unknown"),
-    ])
+    @pytest.mark.parametrize(
+        "filename,expected",
+        [
+            ("product-brief-foo.md", "product-brief"),
+            ("product_brief_bar.md", "product-brief"),
+            ("foo-discovery-notes.md", "discovery-notes"),
+            ("foo-discovery_notes.md", "discovery-notes"),
+            ("architecture-overview.md", "architecture-doc"),
+            ("my-prd.md", "prd"),
+            ("research-report-q4.md", "research-report"),
+            ("foo-distillate.md", "distillate"),
+            ("changelog.md", "changelog"),
+            ("readme.md", "readme"),
+            ("api-spec.md", "specification"),
+            ("design-doc-v2.md", "design-doc"),
+            ("meeting-notes-2026.md", "meeting-notes"),
+            ("brainstorm-session.md", "brainstorming"),
+            ("user-interview-notes.md", "interview-notes"),
+            ("random-file.md", "unknown"),
+        ],
+    )
     def test_detection(self, filename, expected):
         assert detect_doc_type(filename) == expected
 


### PR DESCRIPTION
## Summary

Two Python files in the bmad-distillator core-skill distribute to consumer repos without passing `ruff format --check`:

- `src/bmad/modules/native/core-skills/bmad-distillator/scripts/analyze_sources.py`
- `src/bmad/modules/native/core-skills/bmad-distillator/scripts/tests/test_analyze_sources.py`

Identified during LSA Phase 1b retry prep by repo-pipeliner — they re-regress on every distro push until formatted upstream.

**Root cause:** compass-engine's `pre-commit baseline` job in `lint-core.yml` sets `SKIP=...,ruff-format,...`, so CI doesn't enforce the hook even though `.pre-commit-config.yaml` defines it. Until that SKIP policy is revisited, any reformat must be applied deliberately in source.

**This PR:** runs `ruff format` on those two files only. Pure whitespace diff (dict/set literal layout, call-argument reflow) — no semantic change.

## Verification

```
$ ruff format --check src/bmad/modules/native/core-skills/bmad-distillator/scripts/
2 files already formatted
```

## Test plan

- [ ] Next compass-engine dist push lands ruff-clean content into `_bmad/core/bmad-distillator/scripts/` on all 16 targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved code formatting and layout consistency in internal analysis scripts and tests.

---

**Note:** This release contains only internal code formatting improvements with no changes to user-facing functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->