### PR TITLE
fix(ci): enforce ruff-format in pre-commit baseline

### DIFF
--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Run pre-commit (PR diff, full on protected push)
         run: |
-          export SKIP="end-of-file-fixer,trailing-whitespace,pyupgrade,isort,ruff-check,ruff-format,biome-ci,prettier,actionlint,markdownlint"
+          export SKIP="end-of-file-fixer,trailing-whitespace,pyupgrade,isort,ruff-check,biome-ci,prettier,actionlint,markdownlint"
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             FROM_REF="${{ github.event.pull_request.base.sha }}"

--- a/src/github/workflows/lint-core.yml
+++ b/src/github/workflows/lint-core.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Run pre-commit (PR diff, full on protected push)
         run: |
-          export SKIP="end-of-file-fixer,trailing-whitespace,pyupgrade,isort,ruff-check,ruff-format,biome-ci,prettier,actionlint,markdownlint"
+          export SKIP="end-of-file-fixer,trailing-whitespace,pyupgrade,isort,ruff-check,biome-ci,prettier,actionlint,markdownlint"
 
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             FROM_REF="${{ github.event.pull_request.base.sha }}"


### PR DESCRIPTION
## Summary

Task #39. Remove `ruff-format` from the `SKIP` list in `lint-core.yml`'s `pre-commit baseline` job so CI enforces the ruff-format hook that `.pre-commit-config.yaml` already defines.

**Why it drifted:** previously the hook ran locally on commit but the CI SKIP mask silenced it, allowing unformatted Python files to ship — e.g., `bmad-distillator/scripts/analyze_sources.py` and tests, fixed mechanically in #127.

**Preflight:** `ruff format --check src/` returns clean on this branch; nothing to reformat upstream.

## Test plan

- [ ] This PR's own `pre-commit baseline` job runs ruff-format and passes
- [ ] Next distillator/script change that forgets ruff-format will fail CI at the source instead of drifting downstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration for code formatting validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->