### PR TITLE
fix(ci): remove push trigger from PR-enforced workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,18 +1,6 @@
 name: CodeQL Security Scanning
 
 on:
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - 'reference/BMAD/research/**'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
   pull_request:
     branches: [main, develop]
     paths-ignore:

--- a/.github/workflows/lint-core.yml
+++ b/.github/workflows/lint-core.yml
@@ -14,18 +14,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - 'reference/BMAD/research/**'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
 
 permissions:
   contents: read

--- a/.github/workflows/lint-languages.yml
+++ b/.github/workflows/lint-languages.yml
@@ -14,18 +14,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - 'reference/BMAD/research/**'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
 
 permissions:
   contents: read

--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -13,17 +13,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
 
 env:
   ALLOWED_LICENSES: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, WTFPL, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Python-2.0, PSF-2.0, MPL-2.0

--- a/.github/workflows/submodule-security-monitoring.yml
+++ b/.github/workflows/submodule-security-monitoring.yml
@@ -14,18 +14,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
   schedule:
     - cron: '30 9 * * *'
   workflow_dispatch:

--- a/src/github/workflows/codeql.yml
+++ b/src/github/workflows/codeql.yml
@@ -1,18 +1,6 @@
 name: CodeQL Security Scanning
 
 on:
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - 'reference/BMAD/research/**'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
   pull_request:
     branches: [main, develop]
     paths-ignore:

--- a/src/github/workflows/lint-core.yml
+++ b/src/github/workflows/lint-core.yml
@@ -14,18 +14,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - 'reference/BMAD/research/**'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
 
 permissions:
   contents: read

--- a/src/github/workflows/lint-languages.yml
+++ b/src/github/workflows/lint-languages.yml
@@ -14,18 +14,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - 'reference/BMAD/research/**'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
 
 permissions:
   contents: read

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -13,17 +13,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
 
 env:
   ALLOWED_LICENSES: MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense, WTFPL, CC0-1.0, CC-BY-3.0, CC-BY-4.0, Python-2.0, PSF-2.0, MPL-2.0

--- a/src/github/workflows/submodule-security-monitoring.yml
+++ b/src/github/workflows/submodule-security-monitoring.yml
@@ -14,18 +14,6 @@ on:
       - '**/*.ico'
       - '**/*.webp'
       - '**/*.pdf'
-  push:
-    branches: [main, develop]
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.png'
-      - '**/*.jpg'
-      - '**/*.jpeg'
-      - '**/*.gif'
-      - '**/*.svg'
-      - '**/*.ico'
-      - '**/*.webp'
-      - '**/*.pdf'
   schedule:
     - cron: '30 9 * * *'
   workflow_dispatch:


### PR DESCRIPTION
## Summary

Task #43. Resolves the dual-trigger concurrency race where push + pull_request events both fire for the same branch, the concurrency group cancels one, and GitHub's required-check evaluator sees CANCELLED + SUCCESS and marks the requirement unmet.

**Fix (Option A per team-lead's guidance):** drop the push trigger entirely from workflows that also run on pull_request. Post-merge main-branch coverage comes from the PR run that produced the merge commit. Scheduled runs and workflow_dispatch are preserved where they existed (CodeQL weekly cron, submodule-security-monitoring daily cron).

## Files changed

Removed `push:` trigger block only (no other changes):

- `src/github/workflows/codeql.yml` — keeps `pull_request` + weekly `schedule`
- `src/github/workflows/lint-core.yml` — `pull_request`-only
- `src/github/workflows/lint-languages.yml` — `pull_request`-only
- `src/github/workflows/quality-checks.yml` — `pull_request`-only
- `src/github/workflows/submodule-security-monitoring.yml` — keeps `pull_request` + daily `schedule` + `workflow_dispatch`
- Mirrored to `.github/workflows/` via `tools/push.js`

## Test plan

- [ ] This PR's own CI runs (all jobs trigger on the pull_request event)
- [ ] Post-merge, main-branch state is covered by the merged PR's run; no orphan push run cancels anything
- [ ] CodeQL weekly scheduled scan + submodule daily scheduled scan remain scheduled

🤖 Generated with [Claude Code](https://claude.com/claude-code)