### PR TITLE
fix(push): use managed sync for _bmad to preserve consumer-native content

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "check": "npm run validate && npm run check:github-drift && npm run check:root-drift && npm run build && npm run push:no-build -- --dry-run --targets bmad,planning,documentation,claude,codex,opencode,junie,kilocode,github,root",
     "create:bmad-module": "node tools/create-bmad-module.js",
     "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
-    "test:unit": "node --test test/test-*.js test/bmad/quick-dev/*.test.js",
+    "test:unit": "node --test --test-concurrency=1 test/test-*.js test/bmad/quick-dev/*.test.js",
     "test": "npm run test:unit && npm run validate",
     "prepublishOnly": "npm run build"
   },

--- a/test/test-push-fs.js
+++ b/test/test-push-fs.js
@@ -354,6 +354,35 @@ describe('syncManagedTarget', () => {
     );
     assert.equal(destExists, false);
   });
+
+  it('should preserve consumer-native files on first sync into populated dest', async () => {
+    // Regression test for task #40: when compass-engine syncs _bmad into a
+    // consumer that already holds consumer-native subtrees (e.g. LSA's
+    // _bmad/core/lib/), the first managed sync must leave those files intact
+    // because the manifest is absent and previousFiles is empty.
+    const project = await makeTempDir();
+    const source = await makeTempDir();
+    await fs.mkdir(path.join(project, '.git'));
+
+    await writeTree(path.join(project, 'dest'), {
+      'core/lib/context_manager.py': 'consumer-native',
+      'core/module.yaml': 'will be overwritten',
+    });
+    await writeTree(source, {
+      'core/module.yaml': 'from compass-engine',
+      'bmm/module.yaml': 'from compass-engine',
+    });
+
+    await syncManagedTarget(project, source, baseTarget, { dryRun: false });
+
+    const destTree = await readTree(path.join(project, 'dest'));
+    assert.equal(destTree['core/lib/context_manager.py'], 'consumer-native');
+    assert.equal(destTree['core/module.yaml'], 'from compass-engine');
+    assert.equal(destTree['bmm/module.yaml'], 'from compass-engine');
+
+    const manifest = await readManagedManifest(project, 'test-sync.json');
+    assert.deepEqual(manifest.sort(), ['bmm/module.yaml', 'core/module.yaml']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tools/push.js
+++ b/tools/push.js
@@ -77,6 +77,8 @@ const TARGETS = {
     destName: '_bmad',
     distName: '_bmad',
     localOnly: [],
+    syncStrategy: 'managed',
+    manifestName: 'compass-engine-bmad-sync.json',
   },
   planning: {
     destName: 'planning',

--- a/tools/push.js
+++ b/tools/push.js
@@ -292,7 +292,13 @@ async function copySelectedFiles(sourceRoot, destRoot, files) {
 }
 
 async function listFilesRecursive(rootPath, currentPath = rootPath, files = []) {
-  const entries = await fs.readdir(currentPath, { withFileTypes: true });
+  let entries;
+  try {
+    entries = await fs.readdir(currentPath, { withFileTypes: true });
+  } catch (err) {
+    if (err.code === 'ENOENT') return files;
+    throw err;
+  }
   for (const entry of entries) {
     const entryPath = path.join(currentPath, entry.name);
     if (entry.isDirectory()) {


### PR DESCRIPTION
## Summary
- Task #40. The `_bmad` push target previously used the destructive replace strategy: `fs.rm(destPath, { recursive: true, force: true })` wiped the consumer `_bmad/` directory before copying `dist/_bmad` contents. Consumers with native `_bmad` subtrees (e.g. LSA's `_bmad/core/lib/` Python helpers) lost that content on every push.
- Switches `bmad` to `syncStrategy: 'managed'` with manifest `compass-engine-bmad-sync.json`, matching the pattern already used for `.codex`, `.opencode`, `.github`, `planning`, `docs`, etc.
- Managed strategy only owns files listed in its manifest. On first sync into a populated consumer, `previousFiles` is empty, no stale removal happens, and consumer-native paths outside the manifest are preserved. On re-sync, stale removal is bounded to paths compass-engine itself previously synced.

## Test plan
- [x] `npm run test:unit` — new regression test `should preserve consumer-native files on first sync into populated dest` passes alongside existing managed-sync tests (fresh sync, stale removal, preservePaths, dryRun).
- [x] `npm run build` — dist regenerates cleanly.
- [x] `node tools/push.js --all --dry-run` — reports 16 targets discovered.
- [ ] Follow-up post-merge: verify LSA's `_bmad/core/lib/` survives a real push cycle.