### PR TITLE
feat(ci): auto-detect pnpm and gate submodule scan on .gitmodules

### DIFF
--- a/.github/workflows/quality-checks.yml
+++ b/.github/workflows/quality-checks.yml
@@ -36,22 +36,41 @@ jobs:
       - name: Detect Node.js project
         id: detect
         run: |
-          if [ -f package.json ] && [ -f package-lock.json ]; then
+          if [ ! -f package.json ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "pm=" >> "$GITHUB_OUTPUT"
+          elif [ -f pnpm-lock.yaml ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+          elif [ -f package-lock.json ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=npm" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "pm=" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Setup pnpm
+        if: steps.detect.outputs.pm == 'pnpm'
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
 
       - name: Setup Node.js
         if: steps.detect.outputs.run == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: ${{ steps.detect.outputs.pm }}
 
       - name: Install dependencies
         if: steps.detect.outputs.run == 'true'
-        run: npm ci
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm install --frozen-lockfile
+          else
+            npm ci
+          fi
 
       - name: Check test script presence
         id: test_script
@@ -65,11 +84,16 @@ jobs:
 
       - name: Run tests
         if: steps.detect.outputs.run == 'true' && steps.test_script.outputs.present == 'true'
-        run: npm run test:unit
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm run test:unit
+          else
+            npm run test:unit
+          fi
 
       - name: Skip message
         if: steps.detect.outputs.run != 'true'
-        run: echo "No package.json / package-lock.json; skipping Node.js unit tests."
+        run: echo "No package.json with a recognized lockfile (package-lock.json or pnpm-lock.yaml); skipping Node.js unit tests."
 
   validate:
     name: Pre-Push Validation
@@ -95,10 +119,15 @@ jobs:
       - name: Detect Node.js project
         id: detect
         run: |
-          if [ -f package.json ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ ! -f package.json ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "pm=" >> "$GITHUB_OUTPUT"
+          elif [ -f pnpm-lock.yaml ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=npm" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check canonical check script presence
@@ -111,6 +140,12 @@ jobs:
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Setup pnpm
+        if: steps.detect.outputs.pm == 'pnpm' && steps.check_script.outputs.present == 'true'
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+
       - name: Setup Node.js
         if: steps.detect.outputs.run == 'true' && steps.check_script.outputs.present == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
@@ -119,11 +154,21 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.run == 'true' && steps.check_script.outputs.present == 'true'
-        run: npm install
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm install --frozen-lockfile
+          else
+            npm install
+          fi
 
       - name: Run canonical repository check
         if: steps.detect.outputs.run == 'true' && steps.check_script.outputs.present == 'true'
-        run: npm run check
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm run check
+          else
+            npm run check
+          fi
 
       - name: Skip message
         if: steps.detect.outputs.run != 'true' || steps.check_script.outputs.present != 'true'

--- a/.github/workflows/submodule-security-monitoring.yml
+++ b/.github/workflows/submodule-security-monitoring.yml
@@ -34,15 +34,32 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Checkout (sparse)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          sparse-checkout: .
+          fetch-depth: 1
+
+      - name: Detect submodules
+        id: detect
+        run: |
+          if [ -f .gitmodules ]; then
+            echo "has_submodules=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_submodules=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
       # Falls back to GITHUB_TOKEN for repos without secret.
-      - name: Checkout
+      - name: Checkout (with submodules)
+        if: steps.detect.outputs.has_submodules == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
           token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy
+        if: steps.detect.outputs.has_submodules == 'true'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
@@ -57,7 +74,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         id: upload_trivy_sarif
-        if: always()
+        if: steps.detect.outputs.has_submodules == 'true'
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13
         with:
@@ -65,8 +82,12 @@ jobs:
           category: submodule-trivy
 
       - name: Warn when Trivy SARIF upload is unavailable
-        if: steps.upload_trivy_sarif.outcome == 'failure'
+        if: steps.detect.outputs.has_submodules == 'true' && steps.upload_trivy_sarif.outcome == 'failure'
         run: echo "::warning::Trivy SARIF upload was skipped or unavailable; continuing per policy."
+
+      - name: Skip message
+        if: steps.detect.outputs.has_submodules != 'true'
+        run: echo "No .gitmodules file; skipping submodule Trivy scan."
 
   discover-submodules:
     name: Discover Submodules

--- a/src/github/workflows/quality-checks.yml
+++ b/src/github/workflows/quality-checks.yml
@@ -36,22 +36,41 @@ jobs:
       - name: Detect Node.js project
         id: detect
         run: |
-          if [ -f package.json ] && [ -f package-lock.json ]; then
+          if [ ! -f package.json ]; then
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "pm=" >> "$GITHUB_OUTPUT"
+          elif [ -f pnpm-lock.yaml ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+          elif [ -f package-lock.json ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=npm" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "pm=" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Setup pnpm
+        if: steps.detect.outputs.pm == 'pnpm'
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
 
       - name: Setup Node.js
         if: steps.detect.outputs.run == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version: '20'
-          cache: 'npm'
+          cache: ${{ steps.detect.outputs.pm }}
 
       - name: Install dependencies
         if: steps.detect.outputs.run == 'true'
-        run: npm ci
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm install --frozen-lockfile
+          else
+            npm ci
+          fi
 
       - name: Check test script presence
         id: test_script
@@ -65,11 +84,16 @@ jobs:
 
       - name: Run tests
         if: steps.detect.outputs.run == 'true' && steps.test_script.outputs.present == 'true'
-        run: npm run test:unit
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm run test:unit
+          else
+            npm run test:unit
+          fi
 
       - name: Skip message
         if: steps.detect.outputs.run != 'true'
-        run: echo "No package.json / package-lock.json; skipping Node.js unit tests."
+        run: echo "No package.json with a recognized lockfile (package-lock.json or pnpm-lock.yaml); skipping Node.js unit tests."
 
   validate:
     name: Pre-Push Validation
@@ -95,10 +119,15 @@ jobs:
       - name: Detect Node.js project
         id: detect
         run: |
-          if [ -f package.json ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
+          if [ ! -f package.json ]; then
             echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "pm=" >> "$GITHUB_OUTPUT"
+          elif [ -f pnpm-lock.yaml ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "pm=npm" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check canonical check script presence
@@ -111,6 +140,12 @@ jobs:
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Setup pnpm
+        if: steps.detect.outputs.pm == 'pnpm' && steps.check_script.outputs.present == 'true'
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
+        with:
+          run_install: false
+
       - name: Setup Node.js
         if: steps.detect.outputs.run == 'true' && steps.check_script.outputs.present == 'true'
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
@@ -119,11 +154,21 @@ jobs:
 
       - name: Install dependencies
         if: steps.detect.outputs.run == 'true' && steps.check_script.outputs.present == 'true'
-        run: npm install
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm install --frozen-lockfile
+          else
+            npm install
+          fi
 
       - name: Run canonical repository check
         if: steps.detect.outputs.run == 'true' && steps.check_script.outputs.present == 'true'
-        run: npm run check
+        run: |
+          if [ "${{ steps.detect.outputs.pm }}" = "pnpm" ]; then
+            pnpm run check
+          else
+            npm run check
+          fi
 
       - name: Skip message
         if: steps.detect.outputs.run != 'true' || steps.check_script.outputs.present != 'true'

--- a/src/github/workflows/submodule-security-monitoring.yml
+++ b/src/github/workflows/submodule-security-monitoring.yml
@@ -34,15 +34,32 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Checkout (sparse)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          sparse-checkout: .
+          fetch-depth: 1
+
+      - name: Detect submodules
+        id: detect
+        run: |
+          if [ -f .gitmodules ]; then
+            echo "has_submodules=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_submodules=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # SUBMODULES_PAT: org-scoped PAT for cross-repo private submodule cloning.
       # Falls back to GITHUB_TOKEN for repos without secret.
-      - name: Checkout
+      - name: Checkout (with submodules)
+        if: steps.detect.outputs.has_submodules == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           submodules: recursive
           token: ${{ secrets.SUBMODULES_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Run Trivy
+        if: steps.detect.outputs.has_submodules == 'true'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: fs
@@ -57,7 +74,7 @@ jobs:
 
       - name: Upload Trivy SARIF
         id: upload_trivy_sarif
-        if: always()
+        if: steps.detect.outputs.has_submodules == 'true'
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@bb471cdcf4dda2c934c5b656f554d43c1434ed13
         with:
@@ -65,8 +82,12 @@ jobs:
           category: submodule-trivy
 
       - name: Warn when Trivy SARIF upload is unavailable
-        if: steps.upload_trivy_sarif.outcome == 'failure'
+        if: steps.detect.outputs.has_submodules == 'true' && steps.upload_trivy_sarif.outcome == 'failure'
         run: echo "::warning::Trivy SARIF upload was skipped or unavailable; continuing per policy."
+
+      - name: Skip message
+        if: steps.detect.outputs.has_submodules != 'true'
+        run: echo "No .gitmodules file; skipping submodule Trivy scan."
 
   discover-submodules:
     name: Discover Submodules


### PR DESCRIPTION
## Summary
- `quality-checks.yml`: auto-detect pnpm-lock.yaml in both `test` and `validate` jobs. Install/run via pnpm/action-setup + pnpm when detected, fall back to npm otherwise.
- `submodule-security-monitoring.yml`: gate the `trivy-submodule-scan` job on `.gitmodules` presence. Sparse-checkout → detect → conditional full checkout + scan. Matches existing `discover-submodules` / `monitor-submodule-upstream` gates.

## Why
Constellation (Tauri/Rust + pnpm, no submodules) currently hand-adapts quality-checks.yml to pnpm, which makes every canonical compass-engine push destructive for that repo. With auto-detection, one canonical workflow serves npm and pnpm consumers alike, and submodule-less repos stop running a redundant filesystem scan.

## Test plan
- [x] `npm run validate` passes
- [x] `npm run test:unit` passes (227/227)
- [x] `npm run build` clean
- [x] `node tools/push.js --dry-run` clean across 16 targets
- [ ] CI green on this branch
- [ ] Post-merge: smoke-test push into constellation (pnpm + no submodules) — constellation can drop its local quality-checks.yml adaptation once canonical lands

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to automatically detect and support multiple Node package managers (npm and pnpm).
  * Improved security scanning workflow to conditionally handle projects with git submodules.
  * Optimized build and test processes with package-manager-specific installation strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->